### PR TITLE
Added secondary index to SocketData table

### DIFF
--- a/modules/dynamo/dynamo_tables.tf
+++ b/modules/dynamo/dynamo_tables.tf
@@ -49,9 +49,24 @@ resource "aws_dynamodb_table" "api_socket_table" {
   read_capacity  = var.int_dynamo_read_capacity
   write_capacity = var.int_dynamo_write_capacity
   hash_key       = "connectionId"
+  non_key_attributes = ["userProfile"]
 
   attribute {
     name = "connectionId"
     type = "S"
+  }
+
+  attribute {
+    name = "userProfile"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name               = "ProfileIndex"
+    hash_key           = "userProfile"
+    range_key          = "connectionId"
+    read_capacity      = var.int_dynamo_read_capacity
+    write_capacity     = var.int_dynamo_write_capacity
+    projection_type    = "ALL"
   }
 }


### PR DESCRIPTION
Updated dynamo tables tf file to add secondary index to SocketData.

Hash Key: userProfile
Sort Key: connectionId

Closes #9 